### PR TITLE
ENG-4594: Phase 3 WordPress Plugin Filter Redirect Url Changes

### DIFF
--- a/class-pressable-onepress-login-plugin.php
+++ b/class-pressable-onepress-login-plugin.php
@@ -13,6 +13,9 @@ final class Pressable_OnePress_Login_Plugin {
 			// Handle login request.
 			add_action( 'plugins_loaded', array( $this, 'handle_server_login_request' ) );
 		}
+
+		// Display OnePress error messages on the login page.
+		add_filter( 'login_message', array( $this, 'display_onepress_error' ) );
 	}
 
 	/** Function for handling an incoming login request */
@@ -136,6 +139,22 @@ final class Pressable_OnePress_Login_Plugin {
 		$additional_hosts = apply_filters( 'onepress_login_additional_hosts', $default_additional_hosts );
 
 		return array_merge( $hosts, $additional_hosts );
+	}
+
+	/**
+	 * Display OnePress error message on the WordPress login page.
+	 *
+	 * @param string $message Existing login message HTML.
+	 *
+	 * @return string Login message HTML with error appended if present.
+	 */
+	public function display_onepress_error( $message ) {
+		if ( isset( $_GET['one_click_error'] ) && ! empty( $_GET['one_click_error'] ) ) {
+			$error = esc_html( rawurldecode( $_GET['one_click_error'] ) );
+			$message .= '<div id="login_error"><strong>OnePress Login:</strong> ' . $error . '</div>';
+		}
+
+		return $message;
 	}
 
 	/**

--- a/class-pressable-onepress-login-plugin.php
+++ b/class-pressable-onepress-login-plugin.php
@@ -166,7 +166,7 @@ final class Pressable_OnePress_Login_Plugin {
 	 * @return string Redirect Url.
 	 */
 	private function filter_redirect_url( $site_id, $user ) {
-		$default_redirect_url = sprintf( 'https://my.pressable.com/sites/%d', $site_id );
+		$default_redirect_url = wp_login_url();
 
 		return apply_filters( 'onepress_login_custom_redirect_url', $default_redirect_url, $site_id, $user );
 	}

--- a/pressable-onepress-login.php
+++ b/pressable-onepress-login.php
@@ -10,7 +10,7 @@ Plugin Name: Pressable OnePress Login
 Plugin URI: https://my.pressable.com
 Description: Pressable OnePress Login for the MyPressable Control Panel.
 Author: Pressable
-Version: 1.3.2
+Version: 1.4.0
 Author URI: https://my.pressable.com/
 License: GPL2
 */


### PR DESCRIPTION
## Summary
- Redirect users to the WordPress login page instead of MyPressable on OnePress token validation failures
- All 4 error paths (empty token, expired token, bad user agent, invalid token) now land on `/wp-login.php` instead of `https://my.pressable.com/sites/{id}`
- The `onepress_login_custom_redirect_url` filter is preserved for anyone who has overridden the default

## Changes
- `class-pressable-onepress-login-plugin.php` — Changed `filter_redirect_url` default from `sprintf('https://my.pressable.com/sites/%d', $site_id)` to `wp_login_url()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display a formatted “OnePress Login” error block on the WordPress login page when a one-click login error is present.

* **Bug Fixes**
  * Use WordPress’s standard login URL generation for redirects after failed authentication, improving redirect reliability.

* **Chores**
  * Plugin version updated to 1.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->